### PR TITLE
Use Services global variable if possible

### DIFF
--- a/experiments/popup.js
+++ b/experiments/popup.js
@@ -1,11 +1,11 @@
-/* global ChromeUtils, libExperiments */
+/* global ChromeUtils, libExperiments, globalThis */
 /* exported popup */
 
 "use strict";
 
 /* eslint-disable no-var */
 var {ExtensionCommon} = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 /* eslint-enable no-var */
 
 // eslint-disable-next-line no-var

--- a/experiments/scoreColumn.js
+++ b/experiments/scoreColumn.js
@@ -1,4 +1,4 @@
-/* global ChromeUtils, libCommon, libExperiments */
+/* global ChromeUtils, libCommon, libExperiments, globalThis */
 /* exported scoreColumn */
 
 "use strict";
@@ -6,7 +6,7 @@
 /* eslint-disable no-var */
 var {ExtensionCommon} = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 var {ExtensionSupport} = ChromeUtils.import("resource:///modules/ExtensionSupport.jsm");
-var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 /* eslint-enable no-var */
 
 const RspamdSpamnessColumn = {};

--- a/experiments/spamHeaders.js
+++ b/experiments/spamHeaders.js
@@ -1,11 +1,11 @@
-/* global ChromeUtils, Components, libExperiments */
+/* global ChromeUtils, Components, libExperiments, globalThis */
 /* exported spamHeaders */
 
 "use strict";
 
 /* eslint-disable no-var */
 var {ExtensionCommon} = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 /* eslint-enable no-var */
 const [majorVersion] = Services.appinfo.platformVersion.split(".", 1);
 // eslint-disable-next-line no-var

--- a/experiments/trainButtons.js
+++ b/experiments/trainButtons.js
@@ -1,11 +1,11 @@
-/* global ChromeUtils, libExperiments */
+/* global ChromeUtils, libExperiments, globalThis */
 /* exported trainButtons */
 
 "use strict";
 
 /* eslint-disable no-var */
 var {ExtensionCommon} = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 /* eslint-enable no-var */
 
 // eslint-disable-next-line no-var


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm for recent versions.