### PR TITLE
Use var for Services global in experiments global to avoid redeclaration error

### DIFF
--- a/experiments/popup.js
+++ b/experiments/popup.js
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-var */
 var {ExtensionCommon} = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+var Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 /* eslint-enable no-var */
 
 // eslint-disable-next-line no-var

--- a/experiments/scoreColumn.js
+++ b/experiments/scoreColumn.js
@@ -6,7 +6,7 @@
 /* eslint-disable no-var */
 var {ExtensionCommon} = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 var {ExtensionSupport} = ChromeUtils.import("resource:///modules/ExtensionSupport.jsm");
-const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+var Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 /* eslint-enable no-var */
 
 const RspamdSpamnessColumn = {};

--- a/experiments/spamHeaders.js
+++ b/experiments/spamHeaders.js
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-var */
 var {ExtensionCommon} = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+var Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 /* eslint-enable no-var */
 const [majorVersion] = Services.appinfo.platformVersion.split(".", 1);
 // eslint-disable-next-line no-var

--- a/experiments/trainButtons.js
+++ b/experiments/trainButtons.js
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-var */
 var {ExtensionCommon} = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+var Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 /* eslint-enable no-var */
 
 // eslint-disable-next-line no-var


### PR DESCRIPTION
Sorry, the change from `var` to `const` in https://github.com/moisseev/rspamd-spamness/pull/31 was wrong.
it looks like the top-level variable with same name can conflict between APIs